### PR TITLE
Leftover from test

### DIFF
--- a/internal/controller/vpcattachment_controller.go
+++ b/internal/controller/vpcattachment_controller.go
@@ -75,12 +75,6 @@ func (r *VPCAttachmentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.Status().Update(ctx, &vpcAttachment); err != nil {
 			return ctrl.Result{}, err
 		}
-		if err := r.Get(ctx, vpcNamespacedName, &vpc); err != nil {
-			return ctrl.Result{}, err
-		}
-		if err := r.Get(ctx, req.NamespacedName, &vpcAttachment); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
 	}
 
 	nad := &nadv1.NetworkAttachmentDefinition{


### PR DESCRIPTION
Must have slipped in somewhere during testing. 🧹 